### PR TITLE
BF: use state of master as the starting point for any new brain in Annexificator

### DIFF
--- a/datalad_crawler/nodes/annex.py
+++ b/datalad_crawler/nodes/annex.py
@@ -684,7 +684,7 @@ class Annexificator(object):
 
         return fpath
 
-    def switch_branch(self, branch, parent=None, must_exist=None, allow_remote=True):
+    def switch_branch(self, branch, parent='master', must_exist=None, allow_remote=True):
         """Node generator to switch branches, returns actual node
 
         Parameters

--- a/datalad_crawler/nodes/annex.py
+++ b/datalad_crawler/nodes/annex.py
@@ -693,7 +693,8 @@ class Annexificator(object):
           Name of the branch
         parent : str or None, optional
           If parent is provided, it will serve as a parent of the branch. If None,
-          detached new branch will be created
+          detached new branch will be created.  By default we now base all
+          other branches on "master" since it would be the most common use-case
         must_exist : bool or None, optional
           If None, doesn't matter.  If True, would fail if branch does not exist.  If
           False, would fail if branch already exists

--- a/datalad_crawler/pipelines/tests/test_balsa.py
+++ b/datalad_crawler/pipelines/tests/test_balsa.py
@@ -221,14 +221,16 @@ def test_balsa_pipeline1(ind, topurl, outd, clonedir):
     # Inspect the tree -- that we have all the branches
     branches = {'master', 'incoming', 'incoming-processed', 'git-annex'}
     eq_(set(repo.get_branches()), branches)
-    assert_not_equal(repo.get_hexsha('master'), repo.get_hexsha('incoming-processed'))
-    # and that one is different from incoming
+    # since now we base incoming on master -- and there were nothing custom
+    # in master after incoming-processed, both branches should be the same
+    eq_(repo.get_hexsha('master'), repo.get_hexsha('incoming-processed'))
+    # but that one is different from incoming
     assert_not_equal(repo.get_hexsha('incoming'), repo.get_hexsha('incoming-processed'))
 
     commits = {b: list(repo.get_branch_commits(b)) for b in branches}
-    eq_(len(commits['incoming']), 1)
-    eq_(len(commits['incoming-processed']), 2)
-    eq_(len(commits['master']), 6)  # all commits out there -- init ds + init crawler + 1*(incoming, processed, merge)
+    eq_(len(commits['incoming']), 1 + 3)  # +3 since now we base on master
+    eq_(len(commits['incoming-processed']), 2 + 3)
+    eq_(len(commits['master']), 5)  # all commits out there -- init ds + init crawler + 1*(incoming, processed)
 
     with chpwd(outd):
         eq_(set(glob('*')), {'dir1', 'file1.nii'})


### PR DESCRIPTION
This should Closes #5 , although I am still not sure if that is the most "kosher" way, it has an advantage that .gitattributes settings of whenever datalad dataset is created, would be inherited in incoming branch.