### PR TITLE
Small bug fixes

### DIFF
--- a/datalad_crawler/nodes/annex.py
+++ b/datalad_crawler/nodes/annex.py
@@ -1320,7 +1320,11 @@ class Annexificator(object):
 
             if aggregate:
                 from datalad.api import aggregate_metadata
-                aggregate_metadata(dataset='^', path=self.repo.path, update_mode='all')
+                aggregate_metadata(
+                    dataset='^',
+                    path=self.repo.path,
+                    update_mode='all',
+                    incremental=True)
 
             if tag and stats:
                 # versions survive only in total_stats

--- a/datalad_crawler/pipelines/crcns.py
+++ b/datalad_crawler/pipelines/crcns.py
@@ -36,9 +36,8 @@ lgr = getLogger("datalad.crawler.pipelines.crcns")
 def fetch_datacite_metadata():
     import json
     # CRCNS.org is publisher-id "cdl.ucbcrcns"
-    arx = 'http://search.datacite.org/api?q=datacentre_symbol:cdl.ucbcrcns' \
-          '&fl=doi,minted,updated,xml&fq=has_metadata:true&fq=is_active:true' \
-          '&rows=1000&start=0&sort=updated+asc&wt=json'
+    # We request all of them at once
+    arx = 'https://api.datacite.org/works?data-center-id=cdl.ucbcrcns&page%5Bsize%5D=1000'
     text = get_cached_url_content(arx, name='crcns', maxage=1)
     return json.loads(text)
 
@@ -70,14 +69,15 @@ def get_metadata(dataset=None):
     rj = fetch_datacite_metadata()
 
     all_datasets = {}
-    for i, json_ in enumerate(rj['response']['docs']):
-        json_xml = json_['xml']
+    for i, json_ in enumerate(rj['data']):
+        json_xml = json_['attributes']['xml']
         if isinstance(json_xml, text_type):
             json_xml = json_xml.encode()
         xml_ = base64.decodestring(json_xml).decode('utf-8')
         reg = re.search('AlternativeTitle.?>CRCNS.org ([^<]*)<', xml_)
 
         if not reg:
+            import pdb; pdb.set_trace()
             lgr.warning("Failed to determine AlternativeTitle within %s", xml_)
             continue
 

--- a/datalad_crawler/pipelines/openfmri.py
+++ b/datalad_crawler/pipelines/openfmri.py
@@ -34,7 +34,7 @@ from datalad.dochelpers import exc_str
 from logging import getLogger
 lgr = getLogger("datalad.crawler.pipelines.openfmri")
 
-TOPURL = "https://openfmri.org/dataset/"
+TOPURL = "https://legacy.openfmri.org/dataset/"
 
 
 # define a pipeline factory function accepting necessary keyword arguments

--- a/datalad_crawler/pipelines/tests/test_openfmri.py
+++ b/datalad_crawler/pipelines/tests/test_openfmri.py
@@ -315,10 +315,13 @@ def test_openfmri_pipeline1(ind, topurl, outd, clonedir):
     # all commits out there:
     # backend set, dataset init, crawler init
     # + 3*(incoming, processed, merge)
-    # + 3*aggregate-metadata update + 2*remove of obsolete metadata object files
+    # + 3*aggregate-metadata update
     #   - 1 since now that incoming starts with master, there is one less merge
-    eq_(len(commits['master']), 16)
-    eq_(len(commits_l['master']), 11)
+    # In --incremental mode there is a side effect of absent now
+    #   2*remove of obsolete metadata object files,
+    #     see https://github.com/datalad/datalad/issues/2772
+    eq_(len(commits['master']), 14)
+    eq_(len(commits_l['master']), 9)
 
     # Check tags for the versions
     eq_(out[0]['datalad_stats'].get_total().versions, ['1.0.0', '1.0.1'])
@@ -345,9 +348,9 @@ def test_openfmri_pipeline1(ind, topurl, outd, clonedir):
     # parents are:
     # commit "[DATALAD] dataset aggregate metadata update\n" in commits_l['master'] and
     # commit "[DATALAD] Added files from extracted archives\n\nFiles processed: 6\n renamed: 2\n +annex: 3\nBranches merged: incoming->incoming-processed\n" in commits_l['incoming-processed']
-    eq_(hexsha(commits_l['master'][2].parents), (commits_l['master'][3].hexsha,
+    eq_(hexsha(commits_l['master'][1].parents), (commits_l['master'][2].hexsha,
                                                  commits_l['incoming-processed'][0].hexsha))
-    eq_(hexsha(commits_l['master'][5].parents), (commits_l['master'][6].hexsha,
+    eq_(hexsha(commits_l['master'][3].parents), (commits_l['master'][4].hexsha,
                                                  commits_l['incoming-processed'][1].hexsha))
 
     with chpwd(outd):


### PR DESCRIPTION
- [x] now seems to have to use `incremental=True` while aggregating metadata for the subdataset all the way to the top.  @mih please verify that this is expected (was not needed before).  Without it it would drop metadata for any other present subdataset in the dataset's superdatasets
- [x] use legacy. of openfmri for crawling (although nothing new is expected there)
- [x] fix metadata fetching for CRCNS (Fixes #15 )