### PR TITLE
TST: Drop stale known_failure_v6's

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ env:
   matrix:
     - DATALAD_REPO_DIRECT=yes
     - DATALAD_REPO_VERSION=5
+    - DATALAD_REPO_VERSION=6
 
 
 before_install:

--- a/datalad_crawler/nodes/tests/test_annex.py
+++ b/datalad_crawler/nodes/tests/test_annex.py
@@ -7,7 +7,6 @@
 #
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 
-from datalad.tests.utils import known_failure_v6
 from datalad.tests.utils import known_failure_direct_mode
 
 
@@ -175,9 +174,9 @@ def _test_annex_file(mode, topdir, topurl, outdir):
 def test_annex_file():
     for mode in ('full', 'fast', 'relaxed',):
         if mode in ('full', 'fast'):
-            yield known_failure_direct_mode(known_failure_v6(_test_annex_file)), mode  #FIXME
+            yield known_failure_direct_mode(_test_annex_file), mode  #FIXME
         else:
-            yield known_failure_v6(_test_annex_file), mode  #FIXME
+            yield _test_annex_file, mode
 
 
 @assert_cwd_unchanged()  # we are passing annex, not chpwd
@@ -227,7 +226,7 @@ def test_add_archive_content_tar():
     # 1. We have a dedicated direct mode test build
     # 2. On a FS where direct mode is enforced, we can't switch
     for direct in (True, False):
-        yield known_failure_v6(_test_add_archive_content_tar), direct  #FIXME: the usual thing: in V6 the repo is dirty in the end, since there are files in git falsely marked 'modified'
+        yield _test_add_archive_content_tar, direct
 
 
 @assert_cwd_unchanged()

--- a/datalad_crawler/pipelines/tests/test_balsa.py
+++ b/datalad_crawler/pipelines/tests/test_balsa.py
@@ -7,7 +7,6 @@
 #
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 
-from datalad.tests.utils import known_failure_v6
 from datalad.tests.utils import known_failure_direct_mode
 
 
@@ -129,7 +128,6 @@ TEST_TREE1 = {
 @with_tempfile
 @with_tempfile
 @known_failure_direct_mode  #FIXME
-@known_failure_v6  #FIXME
 def test_balsa_extract_meta(ind, topurl, outd, clonedir):
     list(initiate_dataset(
         template="balsa",
@@ -204,7 +202,6 @@ _PLUG_HERE = '<!-- PLUG HERE -->'
 @with_tempfile
 @with_tempfile
 @known_failure_direct_mode  #FIXME
-@known_failure_v6  #FIXME
 def test_balsa_pipeline1(ind, topurl, outd, clonedir):
     list(initiate_dataset(
         template="balsa",
@@ -315,7 +312,6 @@ _PLUG_HERE = '<!-- PLUG HERE -->'
 @with_tempfile
 @with_tempfile
 @known_failure_direct_mode  #FIXME
-@known_failure_v6  #FIXME
 def test_balsa_pipeline2(ind, topurl, outd, clonedir):
     list(initiate_dataset(
         template="balsa",

--- a/datalad_crawler/pipelines/tests/test_openfmri.py
+++ b/datalad_crawler/pipelines/tests/test_openfmri.py
@@ -202,7 +202,6 @@ _versioned_files = """
 @with_tempfile
 @with_tempfile
 @known_failure_direct_mode  #FIXME
-@known_failure_v6  #FIXME
 def test_openfmri_addperms(ind, topurl, outd, clonedir):
     index_html = opj(ind, 'ds666', 'index.html')
 

--- a/datalad_crawler/pipelines/tests/test_simple_with_archives.py
+++ b/datalad_crawler/pipelines/tests/test_simple_with_archives.py
@@ -23,6 +23,7 @@ from datalad.tests.utils import serve_path_via_http
 from datalad.tests.utils import ok_file_has_content
 from datalad.tests.utils import ok_file_under_git, ok_clean_git
 from datalad.tests.utils import usecase
+from datalad.tests.utils import known_failure_v6
 from ..simple_with_archives import pipeline
 from datalad.api import create
 
@@ -42,6 +43,7 @@ from .test_balsa import TEST_TREE1
 @with_tree(tree=TEST_TREE1, archives_leading_dir=False)
 @serve_path_via_http
 @with_tempfile
+@known_failure_v6  # FIXME
 @known_failure_direct_mode  #FIXME
 def test_simple1(ind, topurl, outd):
 

--- a/datalad_crawler/tests/test_crawl_init.py
+++ b/datalad_crawler/tests/test_crawl_init.py
@@ -8,7 +8,6 @@
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 
 
-from datalad.tests.utils import known_failure_v6
 from datalad.tests.utils import known_failure_direct_mode
 
 
@@ -46,8 +45,7 @@ def test_crawl_init():
           '[crawl:pipeline]\ntemplate = openfmri\n_dataset = ds000001\n\n'
     yield _test_crawl_init, ['dataset=ds000001', 'versioned_urls=True'], 'openfmri', None, False, \
           '[crawl:pipeline]\ntemplate = openfmri\n_dataset = ds000001\n_versioned_urls = True\n\n'
-    #FIXME:
-    yield known_failure_v6(_test_crawl_init), None, 'openfmri', 'superdataset_pipeline', True, \
+    yield _test_crawl_init, None, 'openfmri', 'superdataset_pipeline', True, \
           '[crawl:pipeline]\ntemplate = openfmri\nfunc = superdataset_pipeline\n\n'
 
 


### PR DESCRIPTION
These tests no longer fail in V6 mode with the current DataLad (v0.11.0) and its minimum git-annex version (6.20180913).

---

The only remaining usage of `known_failure_v6` is in test_openfmri.py.  Under V6, these fail with

```
  File "/home/kyle/src/python/datalad-crawler/datalad_crawler/dbs/base.py", line 86, in save
    with open(self._filepath, 'w') as f:
IOError: [Errno 13] Permission denied: '[...]/.datalad/crawl/statuses/incoming.json'
```

suggesting that the crawler should set git attributes so that that file (and perhaps others) is added to git rather than the annex.
