### PR TITLE
RF: Import crawler-specific helper from -core

### DIFF
--- a/datalad_crawler/base.py
+++ b/datalad_crawler/base.py
@@ -12,3 +12,13 @@
 
 __docformat__ = 'restructuredtext'
 
+from datalad import cfg
+from datalad.cmd import Runner
+from datalad.support.protocol import DryRunProtocol
+
+
+def get_runner(*args, **kwargs):
+    if cfg.obtain('datalad.crawl.dryrun', default=False):
+        kwargs = kwargs.copy()
+        kwargs['protocol'] = DryRunProtocol()
+    return Runner(*args, **kwargs)

--- a/datalad_crawler/nodes/annex.py
+++ b/datalad_crawler/nodes/annex.py
@@ -46,8 +46,8 @@ from datalad.support.network import get_url_straight_filename
 from datalad.support.network import get_url_disposition_filename
 
 from datalad import cfg
-from datalad.cmd import get_runner
 
+from datalad_crawler.base import get_runner
 from datalad_crawler.pipeline import initiate_pipeline_config
 from datalad_crawler.dbs.files import PhysicalFileStatusesDB
 from datalad_crawler.dbs.files import JsonFileStatusesDB


### PR DESCRIPTION
This is part of an effort to clean things up in the older parts of datalad-core.

... but it seems cursed...