### PR TITLE
BF(workaround): install p7zip-full so we do not get stuck testing .gz files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ before_install:
   - travis_retry sudo apt-get install eatmydata  # to speedup some installations
   # install git-annex with the relevant bits
   # no recommends to avoid inheriting the entire multimedia stack
-  - travis_retry sudo eatmydata apt-get install --no-install-recommends git-annex-standalone aria2 git-remote-gcrypt lsof gnupg nocache
+  - travis_retry sudo eatmydata apt-get install --no-install-recommends git-annex-standalone aria2 git-remote-gcrypt lsof gnupg nocache p7zip-full
 
 install:
   # Install standalone build of git-annex for the recent enough version


### PR DESCRIPTION
DataLad core has a number of improvements in handling of .gz files in
https://github.com/datalad/datalad/pull/3176
but overall proper solution requires RFing of how all the .gz should be handled
including datalad-archives special remote, so they do not rely on any filename
in the header.  That is for now postponed.
Installing p7zip-full should mitigate the issue for now