### PR TITLE
Remove direct mode testing from travis and make crawler depend on non-rc versions of datalad/scrapy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,6 @@ env:
     - COVERAGE=coverage
     - DATALAD_DATASETS_TOPURL=http://datasets-tests.datalad.org
   matrix:
-    - DATALAD_REPO_DIRECT=yes
     - DATALAD_REPO_VERSION=5
     - DATALAD_REPO_VERSION=6
 

--- a/setup.py
+++ b/setup.py
@@ -59,8 +59,8 @@ setup(
     packages=[pkg for pkg in find_packages('.') if pkg.startswith('datalad')],
     # datalad command suite specs from here
     install_requires=[
-        'datalad>=0.10.0.rc3',
-        'scrapy>=1.1.0rc3',  # versioning is primarily for python3 support
+        'datalad>=0.10.0',
+        'scrapy>=1.1.0',  # versioning is primarily for python3 support
     ],
     extras_require={
         'devel-docs': [


### PR DESCRIPTION
See https://github.com/pypa/pip/issues/4969 for IMHO weird behavior of pip in how to treat rcs specified as depends.  Installing the released datalad should also resolve pyliblzma not being installed for python2 for now which was manifested in #29. Correct fix in datalad was submitted: https://github.com/datalad/datalad/pull/3220