### PR TITLE
Update crawler for rev-create promotion

### DIFF
--- a/datalad_crawler/nodes/annex.py
+++ b/datalad_crawler/nodes/annex.py
@@ -140,19 +140,38 @@ class initiate_dataset(object):
 
         backend = self.backend or cfg.obtain('datalad.crawl.default_backend', default='MD5E')
 
-        ds = create(
-                path=path,
-                force=False,
-                # no_annex=False,  # TODO: add as an arg
-                # Passing save arg based on backend was that we need to save only if
-                #  custom backend was specified, but now with dataset id -- should always save
-                # save=not bool(backend),
-                # annex_version=None,
-                annex_backend=backend,
-                #git_opts=None,
-                #annex_opts=None,
-                #annex_init_opts=None
-        )
+        try:
+            ds = create(
+                    path=path,
+                    force=False,
+                    # no_annex=False,  # TODO: add as an arg
+                    # Passing save arg based on backend was that we need to save only if
+                    #  custom backend was specified, but now with dataset id -- should always save
+                    # save=not bool(backend),
+                    # annex_version=None,
+                    annex_backend=backend,
+                    #git_opts=None,
+                    #annex_opts=None,
+                    #annex_init_opts=None
+            )
+        except TypeError:
+            # The exception was probably due to using annex_backend with new
+            # create. Try again without that parameter.
+            #
+            # TODO: Once the minimum DataLad version is 0.12.0, the create call
+            # above should be dropped.
+            ds = create(path=path, force=False)
+            if self.backend or cfg.get('dataset.crawl.default_backend'):
+                if self.backend:
+                    obsolete_method = "pipeline parameter"
+                else:
+                    obsolete_method = "'dataset.crawl.default_backend'"
+                lgr.warning(
+                    "Using backend configured by 'datalad.repo.backend' (%s). "
+                    "Configuring backend with %s is obsolete.",
+                    cfg.obtain("datalad.repo.backend", default="MD5E"),
+                    obsolete_method)
+
         if self.add_to_super:
             # place hack from 'add-to-super' times here
             # MIH: tests indicate that this wants to discover any dataset above

--- a/datalad_crawler/nodes/tests/test_annex.py
+++ b/datalad_crawler/nodes/tests/test_annex.py
@@ -14,10 +14,12 @@ from os import listdir
 from os.path import join as opj, exists, lexists, basename
 from collections import OrderedDict
 from datalad.tests.utils import with_tempfile, eq_, ok_, SkipTest
+import logging
 from mock import patch
 
 from ..annex import initiate_dataset
 from ..annex import Annexificator
+from datalad.utils import swallow_logs
 from datalad.tests.utils import assert_equal, assert_in
 from datalad.tests.utils import assert_raises
 from datalad.tests.utils import assert_true, assert_false
@@ -26,6 +28,7 @@ from datalad.tests.utils import ok_file_under_git
 from datalad.tests.utils import ok_file_has_content
 from datalad.tests.utils import assert_cwd_unchanged
 from datalad.tests.utils import put_file_under_git
+from datalad.tests.utils import skip_if
 from ...pipeline import load_pipeline_from_config
 from datalad_crawler.consts import CRAWLER_META_CONFIG_PATH, DATALAD_SPECIAL_REMOTE, ARCHIVES_SPECIAL_REMOTE
 from datalad.support.stats import ActivityStats
@@ -77,6 +80,34 @@ def test_initiate_dataset(path, path2):
     eq_(annex3.get_file_backend('test2.dat'), 'MD5E')
 
     raise SkipTest("TODO much more")
+
+
+@with_tempfile(mkdir=True)
+@known_failure_direct_mode
+def test_initiate_dataset_new_create_warns(path):
+    try:
+        from datalad.distribution import create
+    except ImportError:
+        # We are on a version of DataLad with the new create.
+        expected_backend = "MD5E"
+        expect_warning = True
+    else:
+        expected_backend = "SHA256E"
+        expect_warning = False
+
+    path = opj(path, 'test')
+    with swallow_logs(new_level=logging.WARNING) as cml:
+        list(initiate_dataset('template', 'testdataset',
+                              backend="SHA256E", path=path)())
+        if expect_warning:
+            assert_in("datalad.repo.backend", cml.out)
+    # DataLad's new create honors datalad.repo.backend rather than the
+    # crawler-specific one.
+    fname = 'test.dat'
+    f = opj(path, fname)
+    annex = put_file_under_git(f, content="test", annexed=True)
+    eq_(annex.get_file_backend(f), expected_backend)
+
 
 
 @with_tree(tree=[

--- a/datalad_crawler/pipelines/tests/test_balsa.py
+++ b/datalad_crawler/pipelines/tests/test_balsa.py
@@ -225,11 +225,15 @@ def test_balsa_pipeline1(ind, topurl, outd, clonedir):
     assert_not_equal(repo.get_hexsha('incoming'), repo.get_hexsha('incoming-processed'))
 
     commits = {b: list(repo.get_branch_commits(b)) for b in branches}
-
-    eq_(len(commits['master']), 5)  # all commits out there -- init ds + init crawler + 1*(incoming, processed)
-
-    eq_(len(commits['incoming']), 1 + 3)  # +3 since now we base on master
-    eq_(len(commits['incoming-processed']), 2 + 3)
+    # all commits out there -- init ds + init crawler + 1*(incoming, processed)
+    # The number of commits in master differs based on the create variant used
+    # (the one DataLad's master makes only one commit).
+    ncommits_master = len(commits["master"])
+    assert_in(ncommits_master, [4, 5])
+    # incoming branches from master but lacks one merge commit.
+    eq_(len(commits['incoming']), ncommits_master - 1)
+    # incoming-processed is on master.
+    eq_(len(commits['incoming-processed']), ncommits_master)
 
     with chpwd(outd):
         eq_(set(glob('*')), {'dir1', 'file1.nii'})

--- a/datalad_crawler/pipelines/tests/test_balsa.py
+++ b/datalad_crawler/pipelines/tests/test_balsa.py
@@ -225,9 +225,11 @@ def test_balsa_pipeline1(ind, topurl, outd, clonedir):
     assert_not_equal(repo.get_hexsha('incoming'), repo.get_hexsha('incoming-processed'))
 
     commits = {b: list(repo.get_branch_commits(b)) for b in branches}
+
+    eq_(len(commits['master']), 5)  # all commits out there -- init ds + init crawler + 1*(incoming, processed)
+
     eq_(len(commits['incoming']), 1 + 3)  # +3 since now we base on master
     eq_(len(commits['incoming-processed']), 2 + 3)
-    eq_(len(commits['master']), 5)  # all commits out there -- init ds + init crawler + 1*(incoming, processed)
 
     with chpwd(outd):
         eq_(set(glob('*')), {'dir1', 'file1.nii'})

--- a/datalad_crawler/pipelines/tests/test_openfmri.py
+++ b/datalad_crawler/pipelines/tests/test_openfmri.py
@@ -322,10 +322,7 @@ def test_openfmri_pipeline1(ind, topurl, outd, clonedir):
     commits = {b: list(repo.get_branch_commits(b)) for b in branches}
     commits_hexsha = {b: list(repo.get_branch_commits(b, value='hexsha')) for b in branches}
     commits_l = {b: list(repo.get_branch_commits(b, limit='left-only')) for b in branches}
-    eq_(len(commits['incoming']), 6)
-    eq_(len(commits_l['incoming']), 6)
-    eq_(len(commits['incoming-processed']), 9)
-    eq_(len(commits_l['incoming-processed']), 6)
+
     # all commits out there:
     # backend set, dataset init, crawler init
     # + 3*(incoming, processed, merge)
@@ -336,6 +333,11 @@ def test_openfmri_pipeline1(ind, topurl, outd, clonedir):
     #     see https://github.com/datalad/datalad/issues/2772
     eq_(len(commits['master']), 14)
     eq_(len(commits_l['master']), 9)
+
+    eq_(len(commits['incoming']), 6)
+    eq_(len(commits_l['incoming']), 6)
+    eq_(len(commits['incoming-processed']), 9)
+    eq_(len(commits_l['incoming-processed']), 6)
 
     # Check tags for the versions
     eq_(out[0]['datalad_stats'].get_total().versions, ['1.0.0', '1.0.1'])
@@ -564,10 +566,6 @@ def test_openfmri_pipeline2(ind, topurl, outd):
     commits = {b: list(repo.get_branch_commits(b)) for b in branches}
     commits_hexsha = {b: list(repo.get_branch_commits(b, value='hexsha')) for b in branches}
     commits_l = {b: list(repo.get_branch_commits(b, limit='left-only')) for b in branches}
-    eq_(len(commits['incoming']), 4)
-    eq_(len(commits_l['incoming']), 4)
-    eq_(len(commits['incoming-processed']), 5)
-    eq_(len(commits_l['incoming-processed']), 4)
 
     # all commits out there:
     # backend set, dataset init, crawler, init, incoming (shares with master -1),
@@ -575,6 +573,11 @@ def test_openfmri_pipeline2(ind, topurl, outd):
     eq_(len(commits['master']), 6)
     # backend set, dataset init, init, merge, aggregate metadata:
     eq_(len(commits_l['master']), 5)
+
+    eq_(len(commits['incoming']), 4)
+    eq_(len(commits_l['incoming']), 4)
+    eq_(len(commits['incoming-processed']), 5)
+    eq_(len(commits_l['incoming-processed']), 4)
 
     # rerun pipeline -- make sure we are on the same in all branches!
     with chpwd(outd):

--- a/datalad_crawler/pipelines/tests/test_openfmri.py
+++ b/datalad_crawler/pipelines/tests/test_openfmri.py
@@ -325,19 +325,21 @@ def test_openfmri_pipeline1(ind, topurl, outd, clonedir):
 
     # all commits out there:
     # backend set, dataset init, crawler init
+    #   (2 or 3 commits, depending on create variant)
     # + 3*(incoming, processed, merge)
     # + 3*aggregate-metadata update
     #   - 1 since now that incoming starts with master, there is one less merge
     # In --incremental mode there is a side effect of absent now
     #   2*remove of obsolete metadata object files,
     #     see https://github.com/datalad/datalad/issues/2772
-    eq_(len(commits['master']), 14)
-    eq_(len(commits_l['master']), 9)
+    ncommits_master = len(commits['master'])
+    assert_in(ncommits_master, [13, 14])
+    assert_in(len(commits_l['master']), [8, 9])
 
-    eq_(len(commits['incoming']), 6)
-    eq_(len(commits_l['incoming']), 6)
-    eq_(len(commits['incoming-processed']), 9)
-    eq_(len(commits_l['incoming-processed']), 6)
+    eq_(len(commits['incoming']), ncommits_master - 8)
+    eq_(len(commits_l['incoming']), ncommits_master - 8)
+    eq_(len(commits['incoming-processed']), ncommits_master - 5)
+    eq_(len(commits_l['incoming-processed']), ncommits_master - 8)
 
     # Check tags for the versions
     eq_(out[0]['datalad_stats'].get_total().versions, ['1.0.0', '1.0.1'])
@@ -347,7 +349,7 @@ def test_openfmri_pipeline1(ind, topurl, outd, clonedir):
 
     # Ben: The tagged ones currently are the ones with the message
     # '[DATALAD] dataset aggregate metadata update\n':
-    eq_(repo_tags[0]['hexsha'], commits_l['master'][-5].hexsha)  # next to the last one
+    eq_(repo_tags[0]['hexsha'], commits_l['master'][4].hexsha)  # next to the last one
     eq_(repo_tags[-1]['hexsha'], commits_l['master'][0].hexsha)  # the last one
 
     def hexsha(l):
@@ -569,15 +571,16 @@ def test_openfmri_pipeline2(ind, topurl, outd):
 
     # all commits out there:
     # backend set, dataset init, crawler, init, incoming (shares with master -1),
+    #   (2 or 3 commits, depending on create variant)
     # incoming-processed, merge, aggregate metadata:
-    eq_(len(commits['master']), 6)
-    # backend set, dataset init, init, merge, aggregate metadata:
-    eq_(len(commits_l['master']), 5)
+    ncommits_master = len(commits['master'])
+    assert_in(ncommits_master, [5, 6])
+    assert_in(len(commits_l['master']), [4, 5])
 
-    eq_(len(commits['incoming']), 4)
-    eq_(len(commits_l['incoming']), 4)
-    eq_(len(commits['incoming-processed']), 5)
-    eq_(len(commits_l['incoming-processed']), 4)
+    eq_(len(commits['incoming']), ncommits_master - 2)
+    eq_(len(commits_l['incoming']), ncommits_master - 2)
+    eq_(len(commits['incoming-processed']), ncommits_master - 1)
+    eq_(len(commits_l['incoming-processed']), ncommits_master - 2)
 
     # rerun pipeline -- make sure we are on the same in all branches!
     with chpwd(outd):

--- a/datalad_crawler/pipelines/tests/test_simple_with_archives.py
+++ b/datalad_crawler/pipelines/tests/test_simple_with_archives.py
@@ -106,7 +106,8 @@ if (external_versions['datalad'] >= '0.11.2'
 @with_tempfile
 @known_failure_direct_mode  #FIXME
 def check_crawl_autoaddtext(gz, ind, topurl, outd):
-    ds = create(outd, text_no_annex=True)
+    ds = create(outd)
+    ds.run_procedure("cfg_text2git")
     with chpwd(outd):  # TODO -- dataset argument
         template_kwargs = {
             'url': topurl,


### PR DESCRIPTION
This prepares the crawler for datalad/datalad#3383.  After these changes, the crawler should be compatible with both `create` variants.  The current tests will check against the old `create`.  Assuming that run passes, I'll push a temporary commit that adjusts the tests to install DataLad from datalad/datalad#3383.
