### PR TITLE
MNT: Update save() call for compatibility with new save

### DIFF
--- a/datalad_crawler/crawl_init.py
+++ b/datalad_crawler/crawl_init.py
@@ -110,4 +110,4 @@ class CrawlInit(Interface):
             from datalad.api import save
             ds = Dataset(curdir)
             ds.repo.add(configfile, git=True)
-            ds.save("committing crawl config file", path=configfile)
+            ds.save(message="committing crawl config file", path=configfile)


### PR DESCRIPTION
As of DataLad 0.12.0rc4 (specifically 889aca241), rev-save() is the
main save() command.  `message` is no longer the first positional
argument, so pass it as a keyword argument.

Re: datalad/datalad#3504
