### PR TITLE
MNT: Adjust imports for compatibility with developmental DataLad

### DIFF
--- a/datalad_crawler/nodes/crawl_url.py
+++ b/datalad_crawler/nodes/crawl_url.py
@@ -14,7 +14,10 @@ from os.path import splitext, dirname, basename
 
 from datalad.utils import updated
 from datalad.dochelpers import exc_str
-from datalad.downloaders.base import DownloadError, UnhandledRedirectError
+from datalad.support.exceptions import (
+    DownloadError,
+    UnhandledRedirectError,
+)
 from datalad.downloaders.providers import Providers
 
 from logging import getLogger

--- a/datalad_crawler/nodes/s3.py
+++ b/datalad_crawler/nodes/s3.py
@@ -22,7 +22,7 @@ from datalad.support.s3 import get_key_url
 from datalad.support.network import iso8601_to_epoch
 from datalad.downloaders.providers import Providers
 from datalad.downloaders.s3 import S3Downloader
-from datalad.downloaders.base import TargetFileAbsent
+from datalad.support.exceptions import TargetFileAbsent
 from ..dbs.versions import SingleVersionDB
 
 from logging import getLogger


### PR DESCRIPTION
datalad.downloaders.base doesn't do a blanket import of
datalad.support.exceptions as of DataLad's 22392ddfc (RF: Discontinue
evil 'import *', 2019-08-26).  As a result, UnhandledRedirectError and
TargetFileAbsent are no longer defined in downloaders.base.

Get exceptions from where they're defined rather than relying on
downloaders.base to have them.