### PR TITLE
RF: Adjust for https://github.com/datalad/datalad/pull/3834

### DIFF
--- a/datalad_crawler/nodes/annex.py
+++ b/datalad_crawler/nodes/annex.py
@@ -822,13 +822,22 @@ class Annexificator(object):
                     lgr.debug("Skipping the merge")
                     return
 
+            # compatibility kludge for API change post DataLad 0.12.2
+            def get_branch_commits(repo, branch, limit, stop):
+                if hasattr(repo, 'get_branch_commits_'):
+                    return repo.get_branch_commits_(
+                        branch, limit, stop)
+                else:
+                    return repo.get_branch_commits(
+                        branch, limit, stop, value='hexsha')
+
             if one_commit_at_a_time:
                 all_to_merge = list(
-                    self.repo.get_branch_commits(
+                    get_branch_commits(
+                        self.repo,
                         branch,
                         limit='left-only',
-                        stop=last_merged_checksum,
-                        value='hexsha'))[::-1]
+                        stop=last_merged_checksum))[::-1]
             else:
                 all_to_merge = [branch]
 

--- a/datalad_crawler/pipelines/tests/test_balsa.py
+++ b/datalad_crawler/pipelines/tests/test_balsa.py
@@ -219,7 +219,9 @@ def test_balsa_pipeline1(ind, topurl, outd, clonedir):
     # but that one is different from incoming
     assert_not_equal(repo.get_hexsha('incoming'), repo.get_hexsha('incoming-processed'))
 
-    commits = {b: list(repo.get_branch_commits(b)) for b in branches}
+    get_branch_commits = repo.get_branch_commits_ \
+        if hasattr(repo, 'get_branch_commits_') else repo.get_branch_commits
+    commits = {b: list(get_branch_commits(b)) for b in branches}
     # all commits out there -- init ds + init crawler + 1*(incoming, processed)
     # The number of commits in master differs based on the create variant used
     # (the one DataLad's master makes only one commit).

--- a/datalad_crawler/pipelines/tests/test_openfmri.py
+++ b/datalad_crawler/pipelines/tests/test_openfmri.py
@@ -323,9 +323,11 @@ def test_openfmri_pipeline1(ind, topurl, outd, clonedir):
     # actually the tree should look quite neat with 1.0.0 tag having 1 parent in incoming
     # 1.0.1 having 1.0.0 and the 2nd commit in incoming as parents
 
-    commits = {b: list(repo.get_branch_commits(b)) for b in branches}
-    commits_hexsha = {b: list(repo.get_branch_commits(b, value='hexsha')) for b in branches}
-    commits_l = {b: list(repo.get_branch_commits(b, limit='left-only')) for b in branches}
+    get_branch_commits = repo.get_branch_commits_ \
+        if hasattr(repo, 'get_branch_commits_') else repo.get_branch_commits
+    commits = {b: list(get_branch_commits(b)) for b in branches}
+    commits_hexsha = {b: list(get_branch_commits(b, value='hexsha')) for b in branches}
+    commits_l = {b: list(get_branch_commits(b, limit='left-only')) for b in branches}
 
     # all commits out there:
     # backend set, dataset init, crawler init
@@ -430,7 +432,7 @@ def test_openfmri_pipeline1(ind, topurl, outd, clonedir):
         out = run_pipeline(pipeline)
     eq_(len(out), 1)
 
-    commits_hexsha_ = {b: list(repo.get_branch_commits(b, value='hexsha')) for b in branches}
+    commits_hexsha_ = {b: list(get_branch_commits(b, value='hexsha')) for b in branches}
     eq_(commits_hexsha, commits_hexsha_)  # i.e. nothing new
     # actually we do manage to add_git 1 (README) since it is generated committed directly to git
     # BUT now fixed -- if not committed (was the same), should be marked as skipped
@@ -457,9 +459,9 @@ def test_openfmri_pipeline1(ind, topurl, outd, clonedir):
 
     # new instance so it re-reads git stuff etc
     # repo = AnnexRepo(outd, create=False)  # to be used in the checks
-    commits_ = {b: list(repo.get_branch_commits(b)) for b in branches}
-    commits_hexsha_ = {b: list(repo.get_branch_commits(b, value='hexsha')) for b in branches}
-    commits_l_ = {b: list(repo.get_branch_commits(b, limit='left-only')) for b in branches}
+    commits_ = {b: list(get_branch_commits(b)) for b in branches}
+    commits_hexsha_ = {b: list(get_branch_commits(b, value='hexsha')) for b in branches}
+    commits_l_ = {b: list(get_branch_commits(b, limit='left-only')) for b in branches}
 
     assert_not_equal(commits_hexsha, commits_hexsha_)
     eq_(out[0]['datalad_stats'], ActivityStats())  # commit happened so stats were consumed
@@ -488,7 +490,7 @@ def test_openfmri_pipeline1(ind, topurl, outd, clonedir):
     incoming_files = repo.get_files('incoming')
     target_incoming_files.remove('ds666_R1.0.0.tar.gz')
     eq_(set(incoming_files), target_incoming_files)
-    commits_hexsha_removed = {b: list(repo.get_branch_commits(b, value='hexsha')) for b in branches}
+    commits_hexsha_removed = {b: list(get_branch_commits(b, value='hexsha')) for b in branches}
     # our 'statuses' database should have recorded the change thus got a diff
     # which propagated through all branches
     for b in 'master', 'incoming-processed':
@@ -568,9 +570,11 @@ def test_openfmri_pipeline2(ind, topurl, outd):
     # actually the tree should look quite neat with 1.0.0 tag having 1 parent in incoming
     # 1.0.1 having 1.0.0 and the 2nd commit in incoming as parents
 
-    commits = {b: list(repo.get_branch_commits(b)) for b in branches}
-    commits_hexsha = {b: list(repo.get_branch_commits(b, value='hexsha')) for b in branches}
-    commits_l = {b: list(repo.get_branch_commits(b, limit='left-only')) for b in branches}
+    get_branch_commits = repo.get_branch_commits_ \
+        if hasattr(repo, 'get_branch_commits_') else repo.get_branch_commits
+    commits = {b: list(get_branch_commits(b)) for b in branches}
+    commits_hexsha = {b: list(get_branch_commits(b, value='hexsha')) for b in branches}
+    commits_l = {b: list(get_branch_commits(b, limit='left-only')) for b in branches}
 
     # all commits out there:
     # backend set, dataset init, crawler, init, incoming (shares with master -1),
@@ -590,7 +594,7 @@ def test_openfmri_pipeline2(ind, topurl, outd):
         out = run_pipeline(pipeline)
     eq_(len(out), 1)
 
-    commits_hexsha_ = {b: list(repo.get_branch_commits(b, value='hexsha')) for b in branches}
+    commits_hexsha_ = {b: list(get_branch_commits(b, value='hexsha')) for b in branches}
     eq_(commits_hexsha, commits_hexsha_)  # i.e. nothing new
     eq_(out[0]['datalad_stats'], ActivityStats(files=2, skipped=2, urls=2))
     eq_(out[0]['datalad_stats'], out[0]['datalad_stats'].get_total())


### PR DESCRIPTION
Sibling PR to https://github.com/datalad/datalad/pull/3834. To be merged when that one hit master.

Repo classes have no `get_branch_commits()` anymore. The crawler uses the test-helper replacement now. it could eventually also swallow that function into its code base.

