### PR TITLE
Add template for Loris Candidate API

### DIFF
--- a/datalad_crawler/pipelines/loris-candidate-api.py
+++ b/datalad_crawler/pipelines/loris-candidate-api.py
@@ -43,34 +43,35 @@ class LorisCandidateAPI:
             if not os.path.exists(visit):
                 os.mkdir(visit)
 
-            yield updated(data, 
-                    {"url": self.url + "/" + visit,
-                     "visit": visit,
-                    }
-                )
+            yield updated(data, {"url": self.url + "/" + visit, "visit": visit,})
 
     def images(self, data):
         response = json.loads(data["response"])
         for file_ in response["Files"]:
             filename = file_["Filename"]
-            yield updated(data, 
-                    {"url": data["url"] + "/" + filename,
-                     "filename": f"{data['visit']}/images/{filename}",
-                    }
-                )
+            yield updated(
+                data,
+                {
+                    "url": data["url"] + "/" + filename,
+                    "filename": "{}/images/{}".format(data["visit"], filename),
+                },
+            )
 
     def instruments(self, data):
         response = json.loads(data["response"])
         meta = response["Meta"]
         for instrument in response["Instruments"]:
-            filename = f"{meta['CandID']}_{data['visit']}_{instrument}"
+            filename = "{}_{}_{}".format(meta["CandID"], data["visit"], instrument)
 
-            yield updated(data, 
-                    {"url": data["url"] + "/" + instrument,
-                     "filename": f"{data['visit']}/instruments/{filename}",
-                    }
-                )
-    
+            yield updated(
+                data,
+                {
+                    "url": data["url"] + "/" + instrument,
+                    "filename": "{}/instruments/{}".format(data["visit"], filename),
+                },
+            )
+
+
 def pipeline(url=None):
     """Pipeline to crawl/annex a LORIS database via the LORIS Candidate API.
     
@@ -93,7 +94,7 @@ def pipeline(url=None):
             " and exclude=*.txt"
             " and exclude=*.tsv",
         ],
-    ) 
+    )
 
     api = LorisCandidateAPI(url)
 
@@ -120,4 +121,3 @@ def pipeline(url=None):
         ],
         annex.finalize(),
     ]
-

--- a/datalad_crawler/pipelines/loris-candidate-api.py
+++ b/datalad_crawler/pipelines/loris-candidate-api.py
@@ -1,0 +1,90 @@
+# emacs: -*- mode: python; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""A pipeline for crawling a LORIS database through the candidate API"""
+import json
+import os
+
+# Import necessary nodes
+from datalad.utils import updated
+from ..nodes.crawl_url import crawl_url
+from ..nodes.annex import Annexificator
+from datalad_crawler.consts import DATALAD_SPECIAL_REMOTE
+
+# Possibly instantiate a logger if you would like to log
+# during pipeline creation
+from logging import getLogger
+
+lgr = getLogger("datalad.crawler.pipelines.kaggle")
+
+
+class add_url_suffix:
+    def __init__(self, url_type, suffix):
+        self.url_type = url_type
+        self.suffix = suffix
+
+    def __call__(self, data):
+        yield updated(data, {self.url_type: data[self.url_type] + self.suffix})
+
+
+class LorisCandidateAPI:
+    def __init__(self, url):
+        self.url = url
+
+    def visits(self, data):
+        response = json.loads(data["response"])
+        for visit in response["Visits"]:
+            yield updated(data, {"visit-url": self.url + "/" + visit})
+
+    def images(self, data):
+        response = json.loads(data["response"])
+        for file_ in response["Files"]:
+            filename = file_["Filename"]
+            yield updated(data, {"url": data["visit-url"] + "/" + filename})
+
+
+def pipeline(url=None):
+    """Pipeline to crawl/annex a LORIS database via the LORIS Candidate API.
+    
+    It will crawl every file matching the format of the $API/candidates/$candID/
+    endpoint as documented in the LORIS API.
+    """
+
+    lgr.info("Creating a pipeline to crawl data files from %s", url)
+    annex = Annexificator(
+        create=False,
+        statusdb="json",
+        special_remotes=[DATALAD_SPECIAL_REMOTE],
+        options=[
+            "-c",
+            "annex.largefiles="
+            "exclude=Makefile and exclude=LICENSE* and exclude=ISSUES*"
+            " and exclude=CHANGES* and exclude=README*"
+            " and exclude=*.[mc] and exclude=dataset*.json"
+            " and exclude=*.txt"
+            " and exclude=*.tsv",
+        ],
+    )
+    api = LorisCandidateAPI(url)
+
+    return [
+        [
+            crawl_url(url),
+            api.visits,
+            [
+                [
+                    # Crawl candidate images
+                    add_url_suffix("visit-url", "/images"),
+                    crawl_url(input="visit-url"),
+                    api.images,
+                    annex,
+                ],
+            ],
+        ],
+        annex.finalize(),
+    ]

--- a/datalad_crawler/pipelines/loris.py
+++ b/datalad_crawler/pipelines/loris.py
@@ -1,0 +1,90 @@
+# emacs: -*- mode: python; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""A pipeline for crawling a LORIS database"""
+
+# Import necessary nodes
+from ..nodes.crawl_url import crawl_url
+from datalad.utils import updated
+from ..nodes.annex import Annexificator
+from datalad_crawler.consts import DATALAD_SPECIAL_REMOTE
+from os.path import basename
+
+
+import json
+# Possibly instantiate a logger if you would like to log
+# during pipeline creation
+from logging import getLogger
+lgr = getLogger("datalad.crawler.pipelines.kaggle")
+
+
+class LorisAPIExtractor(object):
+
+    def __init__(self, apibase=None, annex=None):
+        self.apibase = apibase
+        self.meta    = {}
+        self.repo    = annex.repo
+
+    def __call__(self, data):
+        jsdata = json.loads(data["response"])
+        for candidate in jsdata["Images"]:
+            filename = basename(candidate["Link"])
+            self.meta[filename] = candidate
+            yield updated(data, { "url" : self.apibase + candidate["Link"] })
+        return
+
+    def finalize(self):
+        def _finalize(data):
+            for filename in self.meta:
+                metadata_setter = self.repo.set_metadata(
+                    filename,
+                    reset=self.meta[filename],
+                )
+                for meta in metadata_setter:
+                    lgr.info("Appending metadata to %s", filename)
+            yield data
+        return _finalize
+
+
+def pipeline(url=None, apibase=None):
+    """Pipeline to crawl/annex a LORIS database via the LORIS API.
+    
+    It will crawl every file matching the format of the $API/project/images/
+    endpoint as documented in the LORIS API. Requires a LORIS version
+    which has API v0.0.3-dev (or higher).
+    """
+    if apibase is None:
+        raise RuntimeError("Must set apibase that links are relative to.")
+
+    lgr.info("Creating a pipeline to crawl data files from %s", url)
+    annex = Annexificator(
+                create=False,
+                statusdb='json',
+                special_remotes=[DATALAD_SPECIAL_REMOTE],
+                options=[
+                    "-c",
+                    "annex.largefiles="
+                    "exclude=Makefile and exclude=LICENSE* and exclude=ISSUES*"
+                    " and exclude=CHANGES* and exclude=README*"
+                    " and exclude=*.[mc] and exclude=dataset*.json"
+                    " and exclude=*.txt"
+                    " and exclude=*.tsv"
+                ]
+    )
+    lorisapi = LorisAPIExtractor(apibase, annex)
+
+    return [
+        # Get the list of images
+        [
+            crawl_url(url),
+            lorisapi,
+            annex,
+        ],
+        annex.finalize(),
+        lorisapi.finalize(),
+    ]


### PR DESCRIPTION
This is an initial template to crawl LORIS specific candidates.
It crawls LORIS Candidate API and annex the images and instruments data of a candidate.