### PR TITLE
Move to DataLad 0.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@
 language: python
 
 python:
-  - 2.7
   - 3.5
   - 3.6
 

--- a/datalad_crawler/nodes/annex.py
+++ b/datalad_crawler/nodes/annex.py
@@ -179,7 +179,11 @@ class initiate_dataset(object):
             sds = ds.get_superdataset(registered_only=False)
             if sds is not None:
                 lgr.debug("Adding %s as a subdataset to %s", ds, sds)
-                sds.add(ds.path, save=False)
+                sds.repo.add_submodule(
+                    str(ds.pathobj.relative_to(sds.pathobj)),
+                    url=None,
+                    name=None,
+                )
                 # this leaves the subdataset staged in the parent
             elif str(self.add_to_super) != 'auto':
                 raise ValueError(

--- a/datalad_crawler/nodes/tests/test_annex.py
+++ b/datalad_crawler/nodes/tests/test_annex.py
@@ -7,9 +7,6 @@
 #
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 
-from datalad.tests.utils import known_failure_direct_mode
-
-
 from os import listdir
 from os.path import join as opj, exists, lexists, basename
 from collections import OrderedDict
@@ -55,7 +52,6 @@ def test_annexificator_no_git_if_dirty(outdir):
 
 @with_tempfile(mkdir=True)
 @with_tempfile()
-@known_failure_direct_mode  #FIXME
 def test_initiate_dataset(path, path2):
     dataset_path = opj(path, 'test')
     datas = list(initiate_dataset('template', 'testdataset', path=dataset_path)())
@@ -83,7 +79,6 @@ def test_initiate_dataset(path, path2):
 
 
 @with_tempfile(mkdir=True)
-@known_failure_direct_mode
 def test_initiate_dataset_new_create_warns(path):
     try:
         from datalad.distribution import create
@@ -204,10 +199,7 @@ def _test_annex_file(mode, topdir, topurl, outdir):
 
 def test_annex_file():
     for mode in ('full', 'fast', 'relaxed',):
-        if mode in ('full', 'fast'):
-            yield known_failure_direct_mode(_test_annex_file), mode  #FIXME
-        else:
-            yield _test_annex_file, mode
+        yield _test_annex_file, mode
 
 
 @assert_cwd_unchanged()  # we are passing annex, not chpwd
@@ -254,7 +246,6 @@ def test_add_archive_content_tar(repo_path):
 @with_tempfile(mkdir=True)
 @with_tree(tree={'file': 'load'})
 @serve_path_via_http
-@known_failure_direct_mode  #FIXME
 def test_add_dir_file(repo_path, p, topurl):
     # test whenever file becomes a directory and then back a file.  Should all work!
     annex = Annexificator(path=repo_path, auto_finalize=False)

--- a/datalad_crawler/pipelines/tests/test_balsa.py
+++ b/datalad_crawler/pipelines/tests/test_balsa.py
@@ -7,9 +7,6 @@
 #
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 
-from datalad.tests.utils import known_failure_direct_mode
-
-
 from datalad_crawler.pipelines.tests.utils import _test_smoke_pipelines
 from ..balsa import pipeline as ofpipeline, superdataset_pipeline
 import os
@@ -127,7 +124,6 @@ TEST_TREE1 = {
 @serve_path_via_http
 @with_tempfile
 @with_tempfile
-@known_failure_direct_mode  #FIXME
 def test_balsa_extract_meta(ind, topurl, outd, clonedir):
     list(initiate_dataset(
         template="balsa",
@@ -201,7 +197,6 @@ _PLUG_HERE = '<!-- PLUG HERE -->'
 @serve_path_via_http
 @with_tempfile
 @with_tempfile
-@known_failure_direct_mode  #FIXME
 def test_balsa_pipeline1(ind, topurl, outd, clonedir):
     list(initiate_dataset(
         template="balsa",
@@ -317,7 +312,6 @@ _PLUG_HERE = '<!-- PLUG HERE -->'
 @serve_path_via_http
 @with_tempfile
 @with_tempfile
-@known_failure_direct_mode  #FIXME
 def test_balsa_pipeline2(ind, topurl, outd, clonedir):
     list(initiate_dataset(
         template="balsa",

--- a/datalad_crawler/pipelines/tests/test_openfmri.py
+++ b/datalad_crawler/pipelines/tests/test_openfmri.py
@@ -8,8 +8,6 @@
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 
 from datalad.tests.utils import known_failure_v6
-from datalad.tests.utils import known_failure_direct_mode
-
 
 import os
 from glob import glob
@@ -211,7 +209,6 @@ _versioned_files = """
 @serve_path_via_http
 @with_tempfile
 @with_tempfile
-@known_failure_direct_mode  #FIXME
 def test_openfmri_addperms(ind, topurl, outd, clonedir):
     index_html = opj(ind, 'ds666', 'index.html')
 
@@ -258,7 +255,6 @@ def test_openfmri_addperms(ind, topurl, outd, clonedir):
 @serve_path_via_http
 @with_tempfile
 @with_tempfile
-@known_failure_direct_mode  #FIXME
 @known_failure_v6  #FIXME
 # unresolved mystery:  https://github.com/datalad/datalad-crawler/issues/55
 @skip_if('2.20.1' <= external_versions['cmd:system-git'] < '2.23.0')
@@ -543,7 +539,6 @@ def test_openfmri_pipeline1(ind, topurl, outd, clonedir):
 )
 @serve_path_via_http
 @with_tempfile
-@known_failure_direct_mode  #FIXME
 @known_failure_v6  #FIXME
 def test_openfmri_pipeline2(ind, topurl, outd):
     # no versioned files -- should still work! ;)

--- a/datalad_crawler/pipelines/tests/test_openfmri_collection.py
+++ b/datalad_crawler/pipelines/tests/test_openfmri_collection.py
@@ -7,8 +7,6 @@
 #
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 
-from datalad.tests.utils import known_failure_direct_mode
-
 import os
 from glob import glob
 from os.path import join as opj, exists
@@ -55,7 +53,6 @@ _PLUG_HERE = '<!-- PLUG HERE -->'
 )
 @serve_path_via_http
 @with_tempfile
-@known_failure_direct_mode  #FIXME
 def test_openfmri_superdataset_pipeline1(ind, topurl, outd):
 
     list(initiate_dataset(

--- a/datalad_crawler/pipelines/tests/test_simple_with_archives.py
+++ b/datalad_crawler/pipelines/tests/test_simple_with_archives.py
@@ -7,9 +7,6 @@
 #
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 
-from datalad.tests.utils import known_failure_direct_mode
-
-
 from os.path import join as opj
 
 from datalad_crawler.pipelines.tests.utils import _test_smoke_pipelines
@@ -53,7 +50,6 @@ from .test_balsa import TEST_TREE1
 @serve_path_via_http
 @with_tempfile
 @known_failure_v6  # FIXME
-@known_failure_direct_mode  #FIXME
 def test_simple1(ind, topurl, outd):
 
     list(initiate_dataset(
@@ -104,7 +100,6 @@ if (external_versions['datalad'] >= '0.11.2'
 @with_tree(tree=TEST_TREE2, archives_leading_dir=False)
 @serve_path_via_http
 @with_tempfile
-@known_failure_direct_mode  #FIXME
 def check_crawl_autoaddtext(gz, ind, topurl, outd):
     ds = create(outd)
     ds.run_procedure("cfg_text2git")

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ except (ImportError, OSError) as exc:
 
 requires = {
     'core': [
-        'datalad>=0.10.0',
+        'datalad>=0.12',
         'scrapy>=1.1.0',  # versioning is primarily for python3 support
     ],
     'devel-docs': [


### PR DESCRIPTION
- stop PY2 test runs
- strip direct mode failure decorators
- stop using obsolete `Dataset.add()`
- depend on DataLad 0.12

Companion to https://github.com/datalad/datalad/pull/4158