### PR TITLE
BF: use AnnexRepo.get_special_remotes after explicit annex info to get special remotes

### DIFF
--- a/datalad_crawler/nodes/annex.py
+++ b/datalad_crawler/nodes/annex.py
@@ -327,15 +327,18 @@ class Annexificator(object):
             if no_annex: # isinstance(self.repo, GitRepo):
                 raise ValueError("Cannot have special remotes in a simple git repo")
 
-            # TODO: move under AnnexRepo with proper testing etc
-            repo_info_repos = [v for k, v in self.repo.repo_info().items()
-                               if k.endswith(' repositories')]
-            annex_remotes = {r['description']: r for r in sum(repo_info_repos, [])}
+            # dummy call to just ensure that git-annex was invoked and possibly initialized
+            self.repo.repo_info()
+            annex_remotes = [
+                r['name'] for r in self.repo.get_special_remotes().values()
+            ]
 
             for remote in special_remotes:
                 if remote not in git_remotes:
                     if remote in annex_remotes:
-                        # Already known - needs only enabling
+                        # Already known - might just need enabling, and since enableremote
+                        # ran on already enabled without any additional options should not have
+                        # side effects, we just try to enable without checking
                         lgr.info("Enabling existing special remote %s" % remote)
                         self.repo.enable_remote(remote)
                     else:


### PR DESCRIPTION
git annex started to autoenable special remotes in more cases.

Recently attention was triggered to it within datalad-extensions testing: https://github.com/datalad/datalad-extensions/pull/18 where test_openfmri started to fail calling `annex initremote` on already enabled `datalad-archives` special remote.

<details>
<summary>An altnerative fix could have been the following</summary> 

```shell
$> git show bf-archives-enable2
commit a08f38f41bc597d846fa01dbcbf6b5528b7bd25f (bf-archives-enable2)
Author: Yaroslav Halchenko <debian@onerussian.com>
Date:   Fri Jul 10 18:29:17 2020 -0400

    BF: Strip [] around remote name while getting known annex remotes
    
    git annex started to enable remotes more readily.  Enabled remote has [] around its
    name.  This elderly crawler code was not ready for that!

diff --git a/datalad_crawler/nodes/annex.py b/datalad_crawler/nodes/annex.py
index 48c8e63..2a83c76 100644
--- a/datalad_crawler/nodes/annex.py
+++ b/datalad_crawler/nodes/annex.py
@@ -330,7 +330,8 @@ class Annexificator(object):
             # TODO: move under AnnexRepo with proper testing etc
             repo_info_repos = [v for k, v in self.repo.repo_info().items()
                                if k.endswith(' repositories')]
-            annex_remotes = {r['description']: r for r in sum(repo_info_repos, [])}
+            annex_remotes = {r['description'].lstrip('[').rstrip(']'): r
+                             for r in sum(repo_info_repos, [])}
 
             for remote in special_remotes:
                 if remote not in git_remotes:

```
</details>

since ad-hoc code we had did not consider enabled remotes since they came surrounded
with `[]`, so it thought that they are "new" and thus tried to call "initremote"
which failed.

Instead of fixing ad-hoc code I have decided to use get_special_remotes.  But
that alone was not sufficient, since git annex might not yet be even "init"ed
and since that "shortcut" function does not invoke any git annex, but rather
parses `remotes.log` in git-annex branch, it would return an empty list.  To
mitigate, I just call old `.repo_info()` which actually talks to annex, possibly
initializing itself.

Unfortunately that test had been skipped for awhile due to "problematic" system wide `git` so we could not even detect it.