### PR TITLE
TST: travis: Upgrade pip before installing datalad

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,7 @@ before_install:
   # install git-annex with the relevant bits
   # no recommends to avoid inheriting the entire multimedia stack
   - travis_retry sudo eatmydata apt-get install --no-install-recommends git-annex-standalone aria2 git-remote-gcrypt lsof gnupg nocache p7zip-full
+  - pip install --upgrade pip
 
 install:
   # Install standalone build of git-annex for the recent enough version


### PR DESCRIPTION
The latest -crawler builds have failures stemming from this:

    pkg_resources.ContextualVersionConflict: (requests 2.25.0
    (/home/travis/virtualenv/python3.5.6/lib/python3.5/site-packages),
    Requirement.parse('requests<2.25,>=2.14.0'), {'PyGithub'})

Follow the same approach as datalad's 6c98c33511 (2020-12-01,
datalad/datalad#5188), and upgrade to the latest pip, which enables a
new dependency resolver by default.

Example: https://travis-ci.com/github/datalad/datalad-crawler/jobs/456690158