### PR TITLE
RF: Discontinue use of feature exclusive to the old DataLad Runner

### DIFF
--- a/datalad_crawler/base.py
+++ b/datalad_crawler/base.py
@@ -11,14 +11,3 @@
 """
 
 __docformat__ = 'restructuredtext'
-
-from datalad import cfg
-from datalad.cmd import Runner
-from datalad.support.protocol import DryRunProtocol
-
-
-def get_runner(*args, **kwargs):
-    if cfg.obtain('datalad.crawl.dryrun', default=False):
-        kwargs = kwargs.copy()
-        kwargs['protocol'] = DryRunProtocol()
-    return Runner(*args, **kwargs)


### PR DESCRIPTION
The new one does not have the ability to "run" Python callables, nor
does it support the old-style protocols.

This is a fairly blind RF attempt, without trying to understand in depth what role `DryRunProtocol` played (or plays in the `crawler` tests.