### PR TITLE
Add dependency on datalad_deprecated

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ except (ImportError, OSError) as exc:
 requires = {
     'core': [
         'datalad>=0.13.6',
+        'datalad_deprecated',
         'scrapy>=1.1.0',  # versioning is primarily for python3 support
     ],
     'devel-docs': [


### PR DESCRIPTION
This extension is co-installable with -core, without breaking it --
regardless of whether or not -core still provides some functionality.

Due to the age of the crawler, it is likely to be affected most by
potential deprecations. Adding this dependency will make it robust
against coming changes, such as the `ls` deprecation
(https://github.com/datalad/datalad/pull/5569).