### PR TITLE
Add LORIS pipelines to crawl LORIS' projects and candidates endpoints

### DIFF
--- a/datalad_crawler/pipelines/loris-candidate-api.py
+++ b/datalad_crawler/pipelines/loris-candidate-api.py
@@ -1,0 +1,123 @@
+# emacs: -*- mode: python; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""A pipeline for crawling a LORIS database through the candidate API"""
+import json
+import os
+
+# Import necessary nodes
+from datalad.utils import updated
+from ..nodes.crawl_url import crawl_url
+from ..nodes.annex import Annexificator
+from datalad_crawler.consts import DATALAD_SPECIAL_REMOTE
+
+# Possibly instantiate a logger if you would like to log
+# during pipeline creation
+from logging import getLogger
+
+lgr = getLogger("datalad.crawler.pipelines.kaggle")
+
+
+class add_url_suffix:
+    def __init__(self, url_type, suffix):
+        self.url_type = url_type
+        self.suffix = suffix
+
+    def __call__(self, data):
+        yield updated(data, {self.url_type: data[self.url_type] + self.suffix})
+
+
+class LorisCandidateAPI:
+    def __init__(self, url):
+        self.url = url
+
+    def visits(self, data):
+        response = json.loads(data["response"])
+        for visit in response["Visits"]:
+
+            if not os.path.exists(visit):
+                os.mkdir(visit)
+
+            yield updated(data, {"url": self.url + "/" + visit, "visit": visit,})
+
+    def images(self, data):
+        response = json.loads(data["response"])
+        for file_ in response["Files"]:
+            filename = file_["Filename"]
+            yield updated(
+                data,
+                {
+                    "url": data["url"] + "/" + filename,
+                    "filename": "{}/images/{}".format(data["visit"], filename),
+                },
+            )
+
+    def instruments(self, data):
+        response = json.loads(data["response"])
+        meta = response["Meta"]
+        for instrument in response["Instruments"]:
+            filename = "{}_{}_{}".format(meta["CandID"], data["visit"], instrument)
+
+            yield updated(
+                data,
+                {
+                    "url": data["url"] + "/" + instrument,
+                    "filename": "{}/instruments/{}".format(data["visit"], filename),
+                },
+            )
+
+
+def pipeline(url=None):
+    """Pipeline to crawl/annex a LORIS database via the LORIS Candidate API.
+    
+    It will crawl every file matching the format of the $API/candidates/$CandID/
+    endpoint as documented in the LORIS API.
+    """
+
+    lgr.info("Creating a pipeline to crawl data files from %s", url)
+
+    annex = Annexificator(
+        skip_problematic=True,
+        statusdb="json",
+        special_remotes=[DATALAD_SPECIAL_REMOTE],
+        options=[
+            "-c",
+            "annex.largefiles="
+            "exclude=Makefile and exclude=LICENSE* and exclude=ISSUES*"
+            " and exclude=CHANGES* and exclude=README*"
+            " and exclude=*.[mc] and exclude=dataset*.json"
+            " and exclude=*.txt"
+            " and exclude=*.tsv",
+        ],
+    )
+
+    api = LorisCandidateAPI(url)
+
+    return [
+        [
+            crawl_url(url),
+            api.visits,
+            [
+                [
+                    # Crawl candidate images
+                    add_url_suffix("url", "/images"),
+                    crawl_url(),
+                    api.images,
+                    annex,
+                ],
+                [
+                    # Crawl candidate insturments
+                    add_url_suffix("url", "/instruments"),
+                    crawl_url(),
+                    api.instruments,
+                    annex,
+                ],
+            ],
+        ],
+        annex.finalize(),
+    ]

--- a/datalad_crawler/pipelines/loris-projects-api.py
+++ b/datalad_crawler/pipelines/loris-projects-api.py
@@ -1,0 +1,352 @@
+# emacs: -*- mode: python; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""A pipeline for crawling a LORIS API for projects endpoints"""
+
+import json
+import re
+from os.path import basename, join
+
+# Import necessary nodes
+from datalad.utils import updated
+from ..nodes.crawl_url import crawl_url
+from ..nodes.annex import Annexificator
+from datalad_crawler.consts import DATALAD_SPECIAL_REMOTE
+
+
+# Possibly instantiate a logger if you would like to log
+# during pipeline creation
+from logging import getLogger
+lgr = getLogger("datalad.crawler.pipelines.kaggle")
+
+
+class ValidateArgs(object):
+    """
+    Class to perform some preliminary validation of the arguments provided to crawl-init.
+    """
+
+    def __init__(self, url=None, endpoints=None):
+        self.url = url
+        self.endpoints = endpoints
+
+    def validate_args(self):
+        """
+        This function will validate that all arguments required are indeed present
+        when running `datalad crawl-init --template loris-projects-api.py`
+
+        :return: error message if the args provided do not pass the validation
+         :rtype: str
+        """
+        cmd_example = "datalad crawl-init --template loris-projects-api.py" \
+                       " url=<loris_base_url>/api/v0.0.3" \
+                       " endpoints=projects/<project_name>/images,projects/<project_name>/candidates"
+
+        if not self.url:
+            return f"\n Please set url that LORIS API endpoints are relative to.\n" \
+                   f" Example:  {cmd_example}\n"
+
+        if not self.endpoints:
+            return f"\n Please set a comma separated list of 'projects' API endpoints to crawl.\n" \
+                   f" Example:  {cmd_example}\n"
+
+    def validate_endpoints(self):
+        """
+        Validate that the list of endpoints provided matches a supported endpoint
+        of loris-projects-api.py template.
+
+        :return: error message that lists the supported endpoints
+         :rtype: str
+        """
+        supported_endpoints = [
+            'projects/<projectName>/images',
+            'projects/<projectName>/bids',
+            'projects/<projectName>/data_releases',
+            'projects/<projectName>/recordings'
+        ]
+        supported_endpoints_pattern = re.compile(
+            r'^projects/.+/((images/?)|(bids/?)|(data_releases/?)|(recordings/?)$)'
+        )
+
+        unsupported_endpoint_bool = False
+        for endpoint in self.endpoints.split(','):
+            if not re.match(supported_endpoints_pattern, endpoint):
+                unsupported_endpoint_bool = True
+
+        if unsupported_endpoint_bool:
+            return f"\n The following endpoint(s) are not supported by this crawler.\n" \
+                   f" List of supported endpoints: {', '.join(supported_endpoints)}\n"
+
+
+class LorisProjectsAPIExtractor(object):
+    """
+    Class that extracts files from the LORIS API projects endpoints
+    """
+
+    def __init__(self, apibase=None, endpoints_list=None):
+        self.apibase = apibase
+        self.endpoints_list = endpoints_list
+
+    def extract_project_images(self, data):
+        """
+        This function reads the JSON response of the LORIS API project images endpoint
+        (<loris-url>/api/<api-version>/projects/<project-name>/images) to crawl.
+
+        Note: there will be two different data organization depending on whether the
+        file downloaded is a MINC file or a NIfTI file:
+            - MINC files will be organized under `candidate/visit/images` folders
+            - NIfTI files will be organized in a BIDS structure
+
+        :param data: the JSON response of the queried API endpoint
+         :type data: dict
+        """
+        response = json.loads(data['response'])
+
+        for file_dict in response['Images']:
+            candid   = file_dict['Candidate']
+            visit    = file_dict['Visit']
+            filename = basename(file_dict['Link'])
+
+            if filename.endswith('.mnc'):
+                # File organization of MINC files
+                yield updated(data, {
+                    "url" : join(self.apibase, 'candidates', candid),
+                    "filename": "candidate.json",
+                    "path": join("MINC_images", candid)
+                })
+                yield updated(data, {
+                    "url" : join(self.apibase, 'candidates', candid, visit),
+                    "filename": "visit.json",
+                    "path": join("MINC_images", candid, visit)
+                })
+                yield updated(data, {
+                    "url" : join(self.apibase, 'candidates', candid, visit, 'images'),
+                    "path": join("MINC_images", candid, visit, 'images')
+                })
+                yield updated(data, {
+                    "url" : self.apibase + file_dict["Link"],
+                    "path": join("MINC_images", candid, visit, 'images')
+                })
+            elif filename.endswith(('.nii', '.nii.gz')):
+                # TODO BIDS file organization
+                # download NIfTI files in sub-<candid>/ses-<visit>/modality
+                # download the sidecar JSON file attached in parameter_file
+                bids_root_dir = 'BIDS_dataset'
+                continue
+
+            break  # TODO remove once done testing
+
+    def extract_projects_data_releases(self, data):
+        """
+        This function reads the JSON response of the LORIS API project data_releases endpoint
+        (<loris-url>/api/<api-version>/projects/<project-name>/data_releases) to crawl.
+
+        :param data: the JSON response of the queried API endpoint
+         :type data: dict
+        """
+        response = json.loads(data['response'])
+
+        # determine the latest version of data release
+        version = None
+        files = []
+        for release in response:
+            current_version = release['Data_Release_Version']
+            if not version:
+                version = current_version
+                files = release['Files']
+            else:
+                version = current_version if current_version > version else version
+                files = release['Files']
+
+        for file_dict in files:
+            file_name = file_dict['File']
+            file_link = file_dict['Link']
+            yield updated(data, {
+                "url"     : join(self.apibase, file_link),
+                "filename": file_name,
+                "path"    : join("non_imaging_data_releases", str(version))
+            })
+            break
+
+    def extract_projects_bids(self, data):
+        """
+        This function reads the JSON response of the LORIS API project bids endpoint
+        (<loris-url>/api/<api-version>/projects/<project-name>/bids) to crawl.
+
+        :param data: the JSON response of the queried API endpoint
+         :type data: dict
+        """
+        bids_root_dir = 'BIDS_dataset'
+        response = json.loads(data['response'])
+
+        for key in ['DatasetDescription', 'README', 'BidsValidatorConfig']:
+            if key in response.keys():
+                yield updated(data, {
+                    'url' : self.apibase + response[key]['Link'],
+                    'path': bids_root_dir
+                })
+
+        if 'Participants' in response.keys():
+            yield updated(data, {
+                'url' : self.apibase + response['Participants']['TsvLink'],
+                'path': bids_root_dir
+            })
+            yield updated(data, {
+                'url' : self.apibase + response['Participants']['JsonLink'],
+                'path': bids_root_dir
+            })
+
+        if 'SessionFiles' in response.keys():
+            for file_dict in response['SessionFiles']:
+                candid = 'sub-' + file_dict['Candidate']
+                visit = 'ses-' + file_dict['Visit']
+                yield updated(data, {
+                    'url' : self.apibase + file_dict['TsvLink'],
+                    'path': join(bids_root_dir, candid, visit)
+                })
+                yield updated(data, {
+                    'url' : self.apibase + file_dict['JsonLink'],
+                    'path': join(bids_root_dir, candid, visit)
+                })
+                break  # TODO remove this once done testing
+
+        if 'Images' in response.keys():
+            for file_dict in response["Images"]:
+                candid = 'sub-' + file_dict["Candidate"]
+                visit = 'ses-' + file_dict["Visit"]
+                subfolder = file_dict['Subfolder']
+                yield updated(data, {
+                    "url" : self.apibase + file_dict["NiftiLink"],
+                    "path": join(bids_root_dir, candid, visit, subfolder)
+                })
+                for associated_file in ['JsonLink', 'BvalLink', 'BvecLink', 'EventLink']:
+                    if associated_file in file_dict:
+                        yield updated(data, {
+                            "url" : self.apibase + file_dict[associated_file],
+                            "path": join(bids_root_dir, candid, visit, subfolder)
+                        })
+                break  # TODO remove this once done testing
+
+    def extract_projects_recordings(self, data):
+        """
+        This function reads the JSON response of the LORIS API project recordings endpoint
+        (<loris-url>/api/<api-version>/projects/<project-name>/recordings) to crawl.
+
+        :param data: the JSON response of the queried API endpoint
+         :type data: dict
+        """
+        response = json.loads(data['response'])
+
+        bids_root_dir = 'BIDS_dataset'
+
+        for file_dict in response['Recordings']:
+            candid    = file_dict['Candidate']
+            visit     = file_dict['Visit']
+            modality  = file_dict['Modality']
+            file_link = file_dict['Link']
+            download_dir = join(bids_root_dir, candid, visit, modality)
+
+            yield updated(data, {
+                'url' : join(self.apibase, file_link),
+                'path': download_dir
+            })
+            yield updated(data, {
+                'url' : join(self.apibase, file_link, 'bidsfiles/channels'),
+                'path': download_dir
+            })
+            yield updated(data, {
+                'url' : join(self.apibase, file_link, 'bidsfiles/events'),
+                'path': download_dir
+             })
+            yield updated(data, {
+                'url' : join(self.apibase, file_link, 'bidsfiles/electrodes'),
+                'path': download_dir
+            })
+            # yield updated(data, {
+            #     'url' : join(self.apibase, file_link, 'bidsfiles/json'),
+            #     'path': download_dir
+            # })
+            break  # TODO remove this once done testing
+
+
+def pipeline(url=None, endpoints=None):
+    """
+    Pipeline to crawl/annex a LORIS database via the LORIS API.
+    
+    It will crawl every file matching the format of the $API/project/images/
+    endpoint as documented in the LORIS API. Requires a LORIS version
+    which has API v0.0.3-dev (or higher).
+    """
+
+    # Checks arguments provided to `datalad crawl-init`
+    # (or stored in `.datalad/crawl/crawl.cfg` config file)
+    arg_validation  = ValidateArgs(url, endpoints)
+    invalid_message = arg_validation.validate_args()
+    if invalid_message:
+        raise RuntimeError(invalid_message)
+    invalid_message = arg_validation.validate_endpoints()
+    if invalid_message:
+        raise RuntimeError(invalid_message)
+
+    # Create the annex object
+    annex = Annexificator(
+                create=False,
+                statusdb='json',
+                skip_problematic=True,
+                special_remotes=[DATALAD_SPECIAL_REMOTE],
+                options=[
+                    "-c",
+                    "annex.largefiles="
+                    "exclude=README.md and exclude=DATS.json and exclude=logo.png"
+                    " and exclude=.datalad/providers/loris.cfg"
+                    " and exclude=.datalad/crawl/crawl.cfg"
+                    " and exclude=*scans.json"
+                    " and exclude=*bval"
+                    " and exclude=BIDS_dataset/dataset_description.json"
+                    " and exclude=BIDS_dataset/participants.json"
+                ]
+    )
+
+    # Initialize the LorisProjectsAPIExtractor class
+    endpoints_list = endpoints.split(',')
+    api_extractor  = LorisProjectsAPIExtractor(url, endpoints_list)
+
+    urls_pipe = [crawl_url(url)]
+    for endpoint in endpoints_list:
+        endpoint_url = join(url, endpoint)
+        lgr.info("Creating a pipeline to crawl data files from %s", join(url, endpoint))
+        if re.match(r'^projects/.+/images/?$', endpoint):
+            urls_pipe += [
+                crawl_url(endpoint_url),
+                api_extractor.extract_project_images,
+                annex
+            ]
+        elif re.match(r'^projects/.+/recordings/?$', endpoint):
+            urls_pipe += [
+                crawl_url(endpoint_url),
+                api_extractor.extract_projects_recordings,
+                annex
+            ]
+        elif re.match(r'^projects/.+/data_releases/?$', endpoint):
+            urls_pipe += [
+                crawl_url(endpoint_url),
+                api_extractor.extract_projects_data_releases,
+                annex
+            ]
+        elif re.match(r'^projects/.+/bids/?$', endpoint):
+            urls_pipe += [
+                crawl_url(endpoint_url),
+                api_extractor.extract_projects_bids,
+                annex
+            ]
+        else:
+            raise RuntimeError(f"\n{endpoint_url} is not supported by this crawler...\n")
+
+    return [
+        urls_pipe,
+        annex.finalize()
+    ]

--- a/datalad_crawler/pipelines/loris-projects-api.py
+++ b/datalad_crawler/pipelines/loris-projects-api.py
@@ -254,22 +254,26 @@ class LorisProjectsAPIExtractor(object):
                 'url' : join(self.apibase, file_link),
                 'path': download_dir
             })
-            yield updated(data, {
-                'url' : join(self.apibase, file_link, 'bidsfiles/channels'),
-                'path': download_dir
-            })
-            yield updated(data, {
-                'url' : join(self.apibase, file_link, 'bidsfiles/events'),
-                'path': download_dir
-             })
-            yield updated(data, {
-                'url' : join(self.apibase, file_link, 'bidsfiles/electrodes'),
-                'path': download_dir
-            })
-            # yield updated(data, {
-            #     'url' : join(self.apibase, file_link, 'bidsfiles/json'),
-            #     'path': download_dir
-            # })
+            if file_dict['ChannelFileLink']:
+                yield updated(data, {
+                    'url' : join(self.apibase, file_link, 'bidsfiles/channels'),
+                    'path': download_dir
+                })
+            if file_dict['ElectrodeFileLink']:
+                yield updated(data, {
+                    'url' : join(self.apibase, file_link, 'bidsfiles/electrodes'),
+                    'path': download_dir
+                 })
+            if file_dict['EventFileLink']:
+                yield updated(data, {
+                    'url' : join(self.apibase, file_link, 'bidsfiles/events'),
+                    'path': download_dir
+                })
+            if file_dict['JSONFileLink']:
+                yield updated(data, {
+                    'url' : join(self.apibase, file_link, 'bidsfiles/json'),
+                    'path': download_dir
+                })
             break  # TODO remove this once done testing
 
 


### PR DESCRIPTION
### Description

This is a refactoring of the scripts that were present in #102 and #13. One of the pipeline present in #67 has also been added to the PR but not changed.

It contains two files:
- `loris-projects-api.py`: to query the different LORIS endpoints specific to projects (a.k.a. under <loris-api-base-url>/projects/) - **still needs work**
- `loris-candidate-api.py`: to query the LORIS endpoints specific to a candidate (a.k.a. under <loris-api-base-url>/candidates/) - for now this is an exact copy of what was in #67 that was submitted by @mathdugre a while back


