### PR TITLE
RF: Adjust for add-archive-content refactoring in datalad core

### DIFF
--- a/datalad_crawler/nodes/annex.py
+++ b/datalad_crawler/nodes/annex.py
@@ -36,7 +36,10 @@ from datalad.utils import try_multiple
 from datalad.utils import assure_list
 
 from datalad.downloaders.providers import Providers
-from datalad.api import create
+from datalad.api import (
+    create,
+    Dataset,
+)
 from datalad.support.gitrepo import GitRepo, _normalize_path
 from datalad.support.annexrepo import AnnexRepo
 from datalad.support.external_versions import external_versions
@@ -1264,15 +1267,18 @@ class Annexificator(object):
             stats = data.get('datalad_stats', ActivityStats())
             archive = self._get_fpath(data, stats)
             # TODO: may be adjust annex_options
-            annex = add_archive_content(
-                archive, annex=self.repo,
-                key=False, commit=commit, allow_dirty=True,
+            add_archive_content(
+                archive,
+                dataset=Dataset(self.repo.path),
+                key=False,
+                commit=commit,
+                allow_dirty=True,
                 annex_options=self.options,
                 stats=stats,
                 **aac_kwargs
             )
             self._states.add("Added files from extracted archives")
-            assert (annex is self.repo)  # must be the same annex, and no new one created
+            #assert (annex is self.repo)  # must be the same annex, and no new one created
             # to propagate statistics from this call into commit msg since we commit=False here
             # we update data with stats which gets a new instance if wasn't present
             yield updated(data, {'datalad_stats': stats})


### PR DESCRIPTION
https://github.com/datalad/datalad/pull/6105 refactors add-archive-content
to be a dataset method. This requires changes in datalad-crawlers
use/adaptation of the function. For one, we need to pass a dataset
instance. Secondly, I had to disable the intergrity check of 'annex',
which used to be returned by add-archive-content, but isn't
anymore.

Locally, this makes the changes in https://github.com/datalad/datalad/pull/6105 not break any crawler tests anymore. It would be great to have your opinion on this, @yarikoptic.