### PR TITLE
RF: remove datalad_deprecated dependency

### DIFF
--- a/datalad_crawler/pipelines/openfmri.py
+++ b/datalad_crawler/pipelines/openfmri.py
@@ -11,6 +11,8 @@
 import os
 from os.path import lexists
 
+from datalad.downloaders.s3 import S3Authenticator
+
 # Import necessary nodes
 from ..nodes.crawl_url import crawl_url
 from ..nodes.matches import a_href_match
@@ -26,7 +28,6 @@ from datalad_crawler.consts import ARCHIVES_SPECIAL_REMOTE
 
 # For S3 crawling
 from .openfmri_s3 import pipeline as s3_pipeline
-from datalad.api import ls
 from datalad.dochelpers import exc_str
 
 # Possibly instantiate a logger if you would like to log
@@ -123,9 +124,9 @@ def pipeline(dataset,
         #     assert suf in 'AB'
         #     s3_prefix = 'ds017' + suf
 
-        openfmri_s3_prefix = 's3://openneuro/'
         try:
-            if not ls('%s%s' % (openfmri_s3_prefix, s3_prefix)):
+            bucket = S3Authenticator().authenticate("openneuro", None)
+            if not next(iter(bucket.list(s3_prefix, "/"))):
                 s3_prefix = None  # not there
         except Exception as exc:
             lgr.warning(

--- a/datalad_crawler/pipelines/xnat.py
+++ b/datalad_crawler/pipelines/xnat.py
@@ -16,32 +16,10 @@ Notes:
   it is
 """
 
-import os
-import re
 import json
-from os.path import lexists
-
-# Import necessary nodes
-from ..nodes.crawl_url import crawl_url
-from ..nodes.matches import css_match, a_href_match
 from ..nodes.misc import assign
-from ..nodes.misc import sub
-from ..nodes.misc import switch
-from ..nodes.misc import func_to_node
-from ..nodes.misc import find_files
-from ..nodes.misc import skip_if
-from ..nodes.misc import debug
-from ..nodes.misc import fix_permissions
 from ..nodes.annex import Annexificator
 from datalad.utils import updated
-from datalad.consts import ARCHIVES_SPECIAL_REMOTE, DATALAD_SPECIAL_REMOTE
-from datalad.downloaders.providers import Providers
-
-# For S3 crawling
-from ..nodes.s3 import crawl_s3
-from .openfmri_s3 import pipeline as s3_pipeline
-from datalad.api import ls
-from datalad.dochelpers import exc_str
 
 # Possibly instantiate a logger if you would like to log
 # during pipeline creation
@@ -51,8 +29,10 @@ lgr = getLogger("datalad.crawler.pipelines.xnat")
 from datalad.tests.utils_pytest import eq_
 from datalad.utils import assure_list, assure_bool
 
+
 def list_to_dict(l, field):
     return {r.pop(field): r for r in l}
+
 
 DEFAULT_RESULT_FIELDS = {'totalrecords', 'result'}
 PROJECT_ACCESS_TYPES = {'public', 'protected', 'private'}
@@ -144,7 +124,7 @@ class XNATServer(object):
 
     def get_projects(self, limit=None, drop_empty=True, asdict=True):
         """Get list of projects 
-        
+
         Parameters
         ----------
         limit: {'public', 'protected', 'private', None} or list of thereof

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,6 @@ with open(opj(dirname(__file__), 'README.md')) as fp:
 requires = {
     'core': [
         'datalad>=0.14.0',
-        'datalad_deprecated',
         'scrapy>=1.1.0',  # versioning is primarily for python3 support
     ],
     'devel-docs': [


### PR DESCRIPTION
Was introduced in https://github.com/datalad/datalad-crawler/pull/94
with only hypothetical assumptions of the necessity.  We are now hypothesizing
that it was not needed