### PR TITLE
BF: import __version__ straight from datalad. not deprecated datalad.version

### DIFF
--- a/datalad_crawler/nodes/annex.py
+++ b/datalad_crawler/nodes/annex.py
@@ -25,7 +25,7 @@ from six import iteritems
 from six import string_types
 from distutils.version import LooseVersion
 
-from datalad.version import __version__
+from datalad import __version__
 from datalad.api import add_archive_content
 from datalad.api import clean
 from datalad.utils import rmtree, updated

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,6 @@ addopts =
 filterwarnings =
     #error
     ignore:distutils Version classes are deprecated:DeprecationWarning
-    ignore:.*datalad.version:DeprecationWarning
     ignore:the imp module is deprecated
 markers =
     # From datalad:


### PR DESCRIPTION
Caused testing to fail in datalad core