### PR TITLE
BF: point to directory with tox.ini while giving it to --cov-config

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ addopts =
     --cov=datalad_crawler
     # Explicitly setting the path to the coverage config file is necessary due
     # to some tests spawning subprocesses with changed working directories.
-    --cov-config=tox.ini
+    --cov-config={toxinidir}/tox.ini
     --no-cov-on-fail
 filterwarnings =
     #error


### PR DESCRIPTION
Without that running tests against this tox.ini from another folder would
make couverage puke since it would look for it in the curdir (e.g. __testhome__)

Discovered while working on https://github.com/datalad/datalad/pull/6914