### PR TITLE
Move definition of `HANDLE_META_DIR` into cralwer

### DIFF
--- a/datalad_crawler/consts.py
+++ b/datalad_crawler/consts.py
@@ -11,9 +11,11 @@
 
 from os.path import join
 
-from datalad.consts import HANDLE_META_DIR
+from datalad.consts import DATALAD_DOTDIR
 from datalad.consts import ARCHIVES_SPECIAL_REMOTE
 from datalad.consts import DATALAD_SPECIAL_REMOTE
+
+HANDLE_META_DIR = DATALAD_DOTDIR
 
 # directory containing prepared metadata of a dataset repository:
 CRAWLER_META_DIR = join(HANDLE_META_DIR, 'crawl')


### PR DESCRIPTION
This commit moves the definition of `HANDLE_META_DIR` into the crawler. It is not used in any other extension and it will not present in datalad anymore after datalad PR #7014 is merged.

