### PR TITLE
Guard usage of the legacy method  `meta_aggregate`, add datalad-deprecated into tests dependencies

### DIFF
--- a/datalad_crawler/nodes/annex.py
+++ b/datalad_crawler/nodes/annex.py
@@ -1339,8 +1339,16 @@ class Annexificator(object):
                 lgr.info("Found branch non-dirty -- nothing was committed")
 
             if aggregate:
-                from datalad.api import aggregate_metadata
-                aggregate_metadata(
+                import datalad.api
+                if not hasattr(datalad.api, 'aggregate_metadata'):
+                    lgr.warning(
+                        "Cannot import `aggregate_metadata` from datalad.api, "
+                        "if you intend metadata aggregation, please install "
+                        "the `datalad-deprecated`-extension or "
+                        "`datalad-metalad < 0.3.0`."
+                    )
+                    return
+                datalad.api.aggregate_metadata(
                     dataset='^',
                     path=self.repo.path,
                     update_mode='all',

--- a/datalad_crawler/pipelines/gh.py
+++ b/datalad_crawler/pipelines/gh.py
@@ -154,8 +154,14 @@ def pipeline(org=None,
                 'dataset_url': repo.clone_url,
             }
 
-
     def do_aggregate_metadata(data):
+        if not hasattr(data['superdataset'], 'aggregate_metadata'):
+            lgr.warning(
+                "Cannot call `aggregate_metadata`. If you intend metadata "
+                "aggregation, please install the `datalad-deprecated`-"
+                "extension, or `datalad-metalad < 0.3.0`."
+            )
+            return
         # For now just aggregate into superdataset, and assume it is always provided!
         agg_out = data['superdataset'].aggregate_metadata(
             data['dataset_path'],

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ requires = {
     ],
     'tests': [
         'datalad>=0.17.0',
+        'datalad-deprecated',
         'pytest>=7.0',
         'pytest-cov',
         'mock',


### PR DESCRIPTION
This PR guards the import and invocation of `aggregate_metadata`, and issues a warning to install either `datalad_deprecated` or
`datalad-metalad < 0.3.0`.

This will become necessary to prevent uncaught exceptions after datalad PR #7014 /https://github.com/datalad/datalad/pull/7014) is merged.
