### PR TITLE
Fix metadata import and dependency on datalad-deprecated

### DIFF
--- a/datalad_crawler/pipelines/tests/test_openfmri.py
+++ b/datalad_crawler/pipelines/tests/test_openfmri.py
@@ -400,13 +400,13 @@ def test_openfmri_pipeline1(ind=None, topurl=None, outd=None, clonedir=None):
 
     try:
         # this is the new way
-        from datalad.metadata.metadata import get_ds_aggregate_db_locations
+        from datalad_deprecated.metadata.metadata import get_ds_aggregate_db_locations
         ds = Dataset('.')
         dbloc, objbase = get_ds_aggregate_db_locations(ds)
         dbloc = op.relpath(dbloc, start=ds.path)
     except ImportError:
         # this stopped working in early 2019 versions of datalad
-        from datalad.metadata.metadata import agginfo_relpath
+        from datalad_deprecated.metadata.metadata import agginfo_relpath
         dbloc = agginfo_relpath
 
     target_files = {

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ requires = {
     ],
     'tests': [
         'datalad>=0.17.0',
-        'datalad-deprecated',
+        'datalad-deprecated>=0.2.6',
         'pytest>=7.0',
         'pytest-cov',
         'mock',


### PR DESCRIPTION
This was tested against a PR in core that removes the metadata related things from core and against a related bugfix PR in datalad-deprecated. Now switched back to regular testing against released dependencies.