### PR TITLE
Swtich release action from EOLed 3.6 (lead to failed release upload to pypi) to 3.11

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.6
+          python-version: '3.11'
 
       - name: Install build & twine
         run: python -m pip install build twine


### PR DESCRIPTION
I will merge/release asap to see if fixes release by releasing 1.0.1