### PR TITLE
Minimal surgery to get github organisations crawling working again

### DIFF
--- a/datalad_crawler/pipelines/gh.py
+++ b/datalad_crawler/pipelines/gh.py
@@ -14,6 +14,8 @@
 
 import re
 
+from datalad import cfg
+
 from datalad.api import Dataset, install
 from datalad.support import path as op
 from datalad.support.gitrepo import GitRepo
@@ -71,8 +73,6 @@ def pipeline(org=None,
     drop_data = assure_bool(drop_data)
 
     import github as gh
-    # TODO: consider elevating that function to a "public" helper
-    from datalad.support.github_ import _gen_github_entity
     superds = Dataset('.')
     if metadata_nativetypes:
         metadata_nativetypes = assure_list_from_str(metadata_nativetypes, sep=',')
@@ -80,10 +80,10 @@ def pipeline(org=None,
     aggregate_later = []
     def crawl_github_org(data):
         assert list(data) == ['datalad_stats'], data
-        # TODO: actually populate the datalad_stats with # of datasets and
-        # possibly amount of data downloaded in get below
-        # Needs DataLad >= 0.13.6~7^2~3 where password was removed
-        entity, cred = next(_gen_github_entity(None, org))
+
+        # TODO: redo with proper integration
+        g = gh.Github(cfg.obtain('hub.oauthtoken'))
+        entity = g.get_organization(org)
         all_repos = list(entity.get_repos(repo_type))
 
         for repo in all_repos:

--- a/datalad_crawler/pipelines/gh.py
+++ b/datalad_crawler/pipelines/gh.py
@@ -121,6 +121,14 @@ def pipeline(org=None,
                 # etc, we will just skip for now
                 continue
 
+            # See if it has anything committed - we will not clone empty ones
+            try:
+                if not any(repo.get_commits()):
+                    raise ValueError("no commits")
+            except Exception as exc:
+                lgr.info("Skipping %s since: %s", name, exc)
+                continue
+
             # TODO: all the recursive etc options
             try:
                 ds = superds.install(

--- a/datalad_crawler/pipelines/tests/test_gh.py
+++ b/datalad_crawler/pipelines/tests/test_gh.py
@@ -19,14 +19,15 @@ from datalad.tests.utils_pytest import (
 )
 import pytest
 
+from ..gh import _get_github_token
 
 @skip_if_no_network
 @with_tempfile
 def test_crawl(tempd=None):
     if not github:
         pytest.skip("no github package")
-    # ATM tests completely overload HOME so TODO: do make it use credentials system
-    if not cfg.get('hub.oauthtoken'):
+    # set DATALAD_TESTS_CREDENTIALS=system to use system credentials
+    if not _get_github_token(obtain=False):
         pytest.skip("no github credentials")
     ds = create(tempd)
     with chpwd(tempd):

--- a/datalad_crawler/pipelines/tests/test_gh.py
+++ b/datalad_crawler/pipelines/tests/test_gh.py
@@ -1,19 +1,15 @@
 from datalad.utils import chpwd
 
+from datalad import cfg
 from datalad.api import (
     crawl,
     crawl_init,
     create,
 )
 try:
-    from datalad.support.github_ import _get_github_cred
+    import github
 except ImportError:
-    # might be dated which has not merged
-    # https://github.com/datalad/datalad/pull/4400 yet
-    from datalad.downloaders.credentials import UserPassword
-    def _get_github_cred():
-        """Trimmed down helper"""
-        return UserPassword("github", "does not matter")
+    github = None
 
 from datalad.tests.utils_pytest import (
     assert_false,
@@ -27,8 +23,11 @@ import pytest
 @skip_if_no_network
 @with_tempfile
 def test_crawl(tempd=None):
-    if not _get_github_cred().is_known:
-        pytest.skip("no github credential")
+    if not github:
+        pytest.skip("no github package")
+    # ATM tests completely overload HOME so TODO: do make it use credentials system
+    if not cfg.get('hub.oauthtoken'):
+        pytest.skip("no github credentials")
     ds = create(tempd)
     with chpwd(tempd):
         crawl_init(


### PR DESCRIPTION
- just use pygithub directly
- use Token credential for `"api.github.com"` or stored in cfg `hub.oauthtoken`