### PR TITLE
BF: Migrate CRCNS DataCite fetch to /dois endpoint

### DIFF
--- a/datalad_crawler/pipelines/crcns.py
+++ b/datalad_crawler/pipelines/crcns.py
@@ -34,9 +34,10 @@ lgr = getLogger("datalad.crawler.pipelines.crcns")
 
 def fetch_datacite_metadata():
     import json
-    # CRCNS.org is publisher-id "cdl.ucbcrcns"
-    # We request all of them at once
-    arx = 'https://api.datacite.org/works?data-center-id=cdl.ucbcrcns&page%5Bsize%5D=1000'
+    # CRCNS.org datasets use DOI prefix 10.6080 (client cdl.ucb, publisher CRCNS.org).
+    # detail=true is required to include the base64-encoded DataCite XML in attributes.xml;
+    # the legacy /works endpoint was retired by DataCite (returns 410 Gone).
+    arx = 'https://api.datacite.org/dois?prefix=10.6080&detail=true&page%5Bsize%5D=1000'
     text = get_cached_url_content(arx, name='crcns', maxage=1)
     return json.loads(text)
 
@@ -79,7 +80,7 @@ def get_metadata(dataset=None):
             lgr.debug("Empty xml in record #%d, skipping for now", i)
             continue
 
-        xml_ = base64.decodestring(json_xml).decode('utf-8')
+        xml_ = base64.b64decode(json_xml).decode('utf-8')
         reg = re.search('AlternativeTitle.?>CRCNS.org ([^<]*)<', xml_)
 
         if not reg:

--- a/datalad_crawler/pipelines/tests/test_crcns.py
+++ b/datalad_crawler/pipelines/tests/test_crcns.py
@@ -43,7 +43,7 @@ def test_get_metadata():
         aa1_meta = get_metadata('aa-1')
         ok_startswith(aa1_meta, '<?xml')
     except AccessFailedError as e:
-        if str(e).startswith('Access to https://search.datacite.org') and \
+        if str(e).startswith('Access to https://api.datacite.org') and \
                 str(e).endswith('has failed: status code 502'):
             pytest.skip("Probably datacite.org blocked us once again")
     except AccessDeniedError:


### PR DESCRIPTION
DataCite retired the legacy /works REST endpoint (returns 410 Gone with a pointer to /dois, /providers, /clients), which broke test_get_metadata in CI. Switch fetch_datacite_metadata to
`/dois?prefix=10.6080&detail=true&page[size]=1000` — prefix 10.6080 is the CRCNS.org DOI namespace, and detail=true is required to include the base64-encoded XML in attributes.xml (list responses omit it by default).

Also swap base64.decodestring for base64.b64decode (the former was removed in Python 3.9) and update the outdated search.datacite.org host check in the skip-on-502 fallback to api.datacite.org so the test still skips gracefully on transient upstream errors.